### PR TITLE
Add missing space for multi equals queries

### DIFF
--- a/force-app/repository/Repository.cls
+++ b/force-app/repository/Repository.cls
@@ -105,7 +105,7 @@ public virtual without sharing class Repository implements IRepository {
       wheres.add(qry.toString());
       this.bindVars.putAll(qry.getBindVars());
     }
-    return wheres.isEmpty() ? '' : '\nWHERE ' + String.join(wheres, '\nAND');
+    return wheres.isEmpty() ? '' : '\nWHERE ' + String.join(wheres, '\nAND ');
   }
 
   private List<SObject> performQuery(String finalQuery) {


### PR DESCRIPTION
Hey there 👋🏻 
Using a list of equals queries does not concatenate properly in the `addWhere` method and throws a query exception.

```
Query query = Query.equals(Opportunity.StageName, 'Prospecting');
Query secondQuery = Query.equals(Opportunity.OwnerId, UserInfo.getProfileId());
Query thirdQuery = Query.equals(Opportunity.LeadSource, 'Advertising');

oppRepo.get(new List<Query> { query, secondQuery, thirdQuery });
```

Query debug: 
```
SELECT Id, IsWon, StageName, Account.Id
FROM Opportunity
WHERE StageName = :bindVar3
ANDOwnerId = :bindVar4
ANDLeadSource = :bindVar5
```

* add space after `\nAND`

Query debug:
```
SELECT Id, IsWon, StageName, Account.Id
FROM Opportunity
WHERE StageName = :bindVar0
AND OwnerId = :bindVar1
AND LeadSource = :bindVar2
```

I've been progressively working through all of the repo's concepts and have to say that it brings much joy and fun as things slowly take shape and the improvements surface!

PS: This has to be smallest PR I've _ever_ opened, I hope its content is actually fixing the issue at the correct spot 😄 