### PR TITLE
Allow "not like" statements to be used with other filters

### DIFF
--- a/force-app/repository/Query.cls
+++ b/force-app/repository/Query.cls
@@ -202,7 +202,7 @@ public virtual class Query {
   public virtual override String toString() {
     if (this.operator == Query.Operator.NOT_LIKE) {
       // who knows why this is the format they wanted
-      return String.format(this.getOperator(), new List<String>{ this.field }) + ' ' + this.predicate;
+      return String.format(this.getOperator(), new List<String>{ this.field, this.predicate.toString() });
     }
     return this.field + ' ' + this.getOperator() + ' ' + this.predicate;
   }
@@ -243,7 +243,7 @@ public virtual class Query {
         returnVal = 'like';
       }
       when NOT_LIKE {
-        returnVal = 'not {0} like';
+        returnVal = '(not {0} like {1})';
       }
     }
     return returnVal;

--- a/force-app/repository/QueryTests.cls
+++ b/force-app/repository/QueryTests.cls
@@ -121,7 +121,7 @@ private class QueryTests {
 
     Query notLike = Query.notLike(Account.Name, expectedName);
 
-    System.assertEquals('not Name like :bindVar0', notLike.toString());
+    System.assertEquals('(not Name like :bindVar0)', notLike.toString());
     System.assertEquals(expectedName, notLike.getBindVars().get('bindVar0'));
   }
 
@@ -133,8 +133,23 @@ private class QueryTests {
 
     Query notLike = Query.notLike(Account.Name, values);
 
-    System.assertEquals('not Name like :bindVar0', notLike.toString());
+    System.assertEquals('(not Name like :bindVar0)', notLike.toString());
     System.assertEquals(values, notLike.getBindVars().get('bindVar0'));
+  }
+
+  @IsTest
+  static void it_should_allow_multiple_not_like_statements() {
+    String someName = '%someName%';
+    String otherName = '%otherName%';
+    
+    Query multipleNotLike = Query.andQuery(new List<Query> {
+      Query.notLike(Account.Name, someName),
+      Query.notLike(Account.Name, otherName)
+    });
+  
+    System.assertEquals('((not Name like :bindVar0) AND (not Name like :bindVar1))', multipleNotLike.toString());
+    System.assertEquals(someName, multipleNotLike.getBindVars().get('bindVar0'));
+    System.assertEquals(otherName, multipleNotLike.getBindVars().get('bindVar1'));
   }
 
   @IsTest


### PR DESCRIPTION
Hi - first, thank you for sharing your blog and this code, it has been really helpful for our team in reducing test execution time and improving code coverage.

We noticed an issue where we were converting a large query that used multiple "not like" statements in it that the query was not valid. The issue seems to be that the correct syntax for a "not like" statement is to have it be wrapped in parentheses so multiple where clauses will work correctly.

For example, the following code would generate a working query:
```apex
Query accountQuery = Query.notLike(Account.Name, '%someName%');
List<Account> accounts = (List<Account>) accountRepo.get(accountQuery);
```
```soql
SELECT Id, Name FROM Account WHERE NOT Name LIKE '%someName%'
```
However, it seems that if we add any other criteria to the query then it will result in a non-valid SOQL query. This seems to be the case if we add any other filter criteria to the where clause, not just if we use multiple "not like" filters.
```apex
Query accountQuery = Query.andQuery(new List<Query> {
    Query.notLike(Account.Name, '%someName%'),
    Query.notLike(Account.Name, '%otherName%')
});
List<Account> accounts = (List<Account>) accountRepo.get(accountQuery);
```
```soql
SELECT Id, Name FROM Account WHERE NOT Name LIKE '%someName%' AND NOT Name LIKE '%otherName%'
```

Instead, the solution seems to be that if we wrap all "not like" queries in parentheses and format the string to include the field name and the value, then we could generate a working query like the one below:
```soql
SELECT Id, Name FROM Account WHERE (NOT Name LIKE '%someName%') AND (NOT Name LIKE '%otherName%')
```

I have written a basic unit test and updated the other two unit tests to expect the added parentheses. The unit tests passed when I ran the updated code in a personal dev sandbox.

Let me know if you have any comments or suggested changes to this!