### PR TITLE
implement adding subselects from another repo

### DIFF
--- a/force-app/repository/IRepository.cls
+++ b/force-app/repository/IRepository.cls
@@ -5,7 +5,6 @@ public interface IRepository extends IDML {
   List<SObject> get(Query query);
   List<SObject> get(List<Query> queries);
   List<SObject> getAll();
-  Set<String> getSelectFields();
 
   List<List<SObject>> getSosl(String searchTerm, Query query);
   List<List<SObject>> getSosl(String searchTerm, List<Query> queries);

--- a/force-app/repository/IRepository.cls
+++ b/force-app/repository/IRepository.cls
@@ -5,6 +5,7 @@ public interface IRepository extends IDML {
   List<SObject> get(Query query);
   List<SObject> get(List<Query> queries);
   List<SObject> getAll();
+  Set<String> getSelectFields();
 
   List<List<SObject>> getSosl(String searchTerm, Query query);
   List<List<SObject>> getSosl(String searchTerm, List<Query> queries);
@@ -23,9 +24,17 @@ public interface IRepository extends IDML {
   IRepository addFunctionBaseFields(SelectFunction selectFunction, Map<Schema.SObjectField, String> fieldsToAliases);
   IRepository addParentFields(List<Schema.SObjectField> relationshipFields, List<Schema.SObjectField> parentFields);
   IRepository addChildFields(Schema.SObjectField childFieldToken, List<SObjectField> childFields);
+  IRepository addChildFields(Schema.SObjectField childFieldToken, IRepository childRepo);
   IRepository addChildFields(
     Schema.SObjectField childFieldToken,
     List<Schema.SObjectField> childFields,
+    List<Query> optionalWhereFilters,
+    Map<String, RepositorySortOrder> fieldToSortOrder,
+    Integer limitBy
+  );
+  IRepository addChildFields(
+    Schema.SObjectField childFieldToken,
+    IRepository childRepo,
     List<Query> optionalWhereFilters,
     Map<String, RepositorySortOrder> fieldToSortOrder,
     Integer limitBy

--- a/force-app/repository/Repository.cls
+++ b/force-app/repository/Repository.cls
@@ -162,7 +162,9 @@ public virtual without sharing class Repository implements IRepository {
     Map<String, RepositorySortOrder> fieldToSortOrder,
     Integer limitBy
   ) {
-    Set<String> localSelectFields = childRepo.getSelectFields();
+    Repository cr = (Repository) childRepo;
+    cr.selectFields.addAll(cr.addSelectFields());
+    Set<String> localSelectFields = cr.selectFields;
     localSelectFields.remove('Id');
 
     return this.addChildFields(
@@ -214,11 +216,6 @@ public virtual without sharing class Repository implements IRepository {
   public Repository clearBindVars() {
     this.bindVars.clear();
     return this;
-  }
-
-  public Set<String> getSelectFields() {
-    this.selectFields.addAll(this.addSelectfields());
-    return this.selectFields;
   }
 
   protected virtual Set<String> addSelectFields() {

--- a/force-app/repository/Repository.cls
+++ b/force-app/repository/Repository.cls
@@ -129,6 +129,16 @@ public virtual without sharing class Repository implements IRepository {
     );
   }
 
+  public Repository addChildFields(Schema.SObjectField childFieldToken, IRepository childRepo) {
+    return this.addChildFields(
+      childFieldToken,
+      childRepo,
+      new List<Query>(),
+      new Map<String, RepositorySortOrder>(),
+      null
+    );
+  }
+
   public Repository addChildFields(
     Schema.SObjectField childFieldToken,
     List<Schema.SObjectField> childFields,
@@ -139,6 +149,25 @@ public virtual without sharing class Repository implements IRepository {
     return this.addChildFields(
       childFieldToken,
       new List<QueryField>{ new QueryField(childFields) },
+      optionalWhereFilters,
+      fieldToSortOrder,
+      limitBy
+    );
+  }
+
+  public Repository addChildFields(
+    Schema.SObjectField childFieldToken,
+    IRepository childRepo,
+    List<Query> optionalWhereFilters,
+    Map<String, RepositorySortOrder> fieldToSortOrder,
+    Integer limitBy
+  ) {
+    Set<String> localSelectFields = childRepo.getSelectFields();
+    localSelectFields.remove('Id');
+
+    return this.addChildFields(
+      childFieldToken,
+      new List<QueryField>{ new QueryField(new List<String>(localSelectFields)) },
       optionalWhereFilters,
       fieldToSortOrder,
       limitBy
@@ -185,6 +214,11 @@ public virtual without sharing class Repository implements IRepository {
   public Repository clearBindVars() {
     this.bindVars.clear();
     return this;
+  }
+
+  public Set<String> getSelectFields() {
+    this.selectFields.addAll(this.addSelectfields());
+    return this.selectFields;
   }
 
   protected virtual Set<String> addSelectFields() {

--- a/force-app/repository/RepositoryTests.cls
+++ b/force-app/repository/RepositoryTests.cls
@@ -129,12 +129,72 @@ private class RepositoryTests {
   }
 
   @IsTest
+  static void it_should_add_child_fields_from_repo() {
+    IRepository repo = new AccountRepo()
+      .addChildFields(
+        Opportunity.AccountId,
+        new OpportunityRepo().addChildFields(OpportunityContactRole.OpportunityId, new OpportunityContactRoleRepo())
+      );
+
+    Account acc = new Account(Name = 'Parent');
+    insert acc;
+    Contact con = new Contact(AccountId = acc.Id, LastName = 'Child Contact');
+    insert con;
+    Opportunity opp = new Opportunity(
+      AccountId = acc.Id,
+      Name = 'Chlid',
+      StageName = Opportunity.StageName.getDescribe().getPicklistValues().get(0).getValue(),
+      CloseDate = Date.today()
+    );
+    insert opp;
+    OpportunityContactRole ocr = new OpportunityContactRole(
+      OpportunityId = opp.Id,
+      ContactId = con.Id,
+      Role = OpportunityContactRole.Role.getDescribe().getPicklistValues().get(0).getValue()
+    );
+    insert ocr;
+
+    List<Account> accounts = repo.getAll();
+    Assert.areEqual(1, accounts.size());
+    Assert.areEqual(1, accounts.get(0).Opportunities.size());
+    Opportunity returnedOpp = accounts.get(0).Opportunities.get(0);
+    Assert.areEqual(opp.Name, returnedOpp.Name);
+    Assert.areEqual(1, returnedOpp.OpportunityContactRoles.size());
+    OpportunityContactRole returnedOcr = returnedOpp.OpportunityContactRoles.get(0);
+    Assert.areEqual(ocr.Role, returnedOcr.Role);
+  }
+
+  @IsTest
   static void it_adds_child_fields_with_filters() {
     String nameFilter = 'Child';
     IRepository repo = new AccountRepo()
       .addChildFields(
         Contact.AccountId,
         new List<Schema.SObjectField>{ Contact.AccountId, Contact.LastName },
+        new List<Query>{ Query.equals(Contact.LastName, nameFilter) },
+        new Map<String, RepositorySortOrder>(),
+        1
+      );
+
+    Account acc = new Account(Name = 'Parent');
+    insert acc;
+    Contact con = new Contact(AccountId = acc.Id, LastName = nameFilter);
+    Contact secondRecord = new Contact(AccountId = acc.Id, LastName = nameFilter);
+    Contact excluded = new Contact(AccountId = acc.Id, LastName = 'Excluded');
+    insert new List<Contact>{ con, secondRecord, excluded };
+
+    List<Account> accounts = repo.getAll();
+    System.assertEquals(1, accounts.size());
+    System.assertEquals(1, accounts.get(0).Contacts.size());
+  }
+
+  @IsTest
+  static void it_adds_child_fields_with_filters_from_repo() {
+    String nameFilter = 'Child';
+    IRepository repo = new AccountRepo()
+      .addChildFields(
+        Contact.AccountId,
+        new ContactRepo(),
         new List<Query>{ Query.equals(Contact.LastName, nameFilter) },
         new Map<String, RepositorySortOrder>(),
         1
@@ -452,6 +512,28 @@ private class RepositoryTests {
   private class AccountRepo extends Repository {
     public AccountRepo() {
       super(Account.SObjectType, new List<Schema.SObjectField>{ Account.Name }, new RepoFactory());
+    }
+  }
+
+  private class ContactRepo extends Repository {
+    public ContactRepo() {
+      super(Contact.SObjectType, new List<Schema.SObjectField>{ Contact.LastName }, new RepoFactory());
+    }
+  }
+
+  private class OpportunityRepo extends Repository {
+    public OpportunityRepo() {
+      super(Opportunity.SObjectType, new List<Schema.SObjectField>{ Opportunity.Name }, new RepoFactory());
+    }
+  }
+
+  private class OpportunityContactRoleRepo extends Repository {
+    public OpportunityContactRoleRepo() {
+      super(
+        OpportunityContactRole.SObjectType,
+        new List<Schema.SObjectField>{ OpportunityContactRole.Role },
+        new RepoFactory()
+      );
     }
   }
 


### PR DESCRIPTION
Dear James,

I recently tested another query builder. Although it implemented the selector pattern and did not support mocking, it had a very striking feature: adding another selector class as child query, and another one on top of that as grandchild.

Here's my implementation for the apex-dml-mocking repository. Again, I documented the usage in the RepositoryTests methods:

- `it_should_add_child_fields_from_repo`
- `it_adds_child_fields_with_filters_from_repo`

One more thing: I didn't add checking for the golden 'five levels of parent-child-queries' rule. Although it's worth considering, I would probably come up with it in a separate pull request, because this feature is kind of critical to my business and I can handle any issues using query exceptions.

Again, thanks for your hard work. Looking forward to testing the new cursors feature soon!

Kind regards,
Jan
