### PR TITLE
fix NOT LIKE query in lists of queries

### DIFF
--- a/.forceignore
+++ b/.forceignore
@@ -1,1 +1,3 @@
 package.xml
+**/jsconfig.json
+**/.eslintrc.json

--- a/.forceignore
+++ b/.forceignore
@@ -1,3 +1,1 @@
 package.xml
-**/jsconfig.json
-**/.eslintrc.json

--- a/force-app/repository/Query.cls
+++ b/force-app/repository/Query.cls
@@ -226,7 +226,7 @@ public virtual class Query {
     String printedValue = ' ' + (shouldPerformStrictEquals ? this.predicate : predicateValue);
     if (this.operator == Query.Operator.NOT_LIKE) {
       // who knows why this is the format they wanted
-      return String.format(this.getOperator(), new List<String>{ this.field }) + printedValue;
+      return '(' + String.format(this.getOperator(), new List<String>{ this.field }) + printedValue + ')';
     }
     return this.field + ' ' + this.getOperator() + printedValue;
   }

--- a/force-app/repository/QueryTest.cls
+++ b/force-app/repository/QueryTest.cls
@@ -140,7 +140,7 @@ private class QueryTest {
     Query notLike = Query.notLike(Account.Name, expectedName);
     Query.shouldPerformStrictEquals = true;
 
-    Assert.areEqual('NOT Name LIKE ' + expectedName, notLike.toString());
+    Assert.areEqual('(NOT Name LIKE ' + expectedName + ')', notLike.toString());
     Assert.areEqual(expectedName, notLike.getBindVars().get('bindVar0'));
   }
 
@@ -153,7 +153,7 @@ private class QueryTest {
     Query notLike = Query.notLike(Account.Name, values);
     Query.shouldPerformStrictEquals = true;
 
-    Assert.areEqual('NOT Name LIKE ' + values, notLike.toString());
+    Assert.areEqual('(NOT Name LIKE ' + values + ')', notLike.toString());
     Assert.areEqual(values, notLike.getBindVars().get('bindVar0'));
   }
 


### PR DESCRIPTION
Dear James, 

I ran into this issue when I was creating my first NOT LIKE query with the apex-dml-mocking repo:

`13:21:58.2 (106312295)|USER_DEBUG|[419]|DEBUG|performQuery query:
SELECT Id, Name
FROM Profile
WHERE Name != null
AND NOT Name LIKE :bindVar0
13:21:58.2 (106329215)|METHOD_EXIT|[335]|01pdL00000SExqc|Repository.logQuery(String)
13:21:58.2 (106333445)|STATEMENT_EXECUTE|[336]
13:21:58.2 (106884528)|EXCEPTION_THROWN|[336]|System.QueryException: unexpected token: 'NOT'
13:21:58.2 (107015711)|HEAP_ALLOCATE|[336]|Bytes:27
13:21:58.2 (107052161)|METHOD_EXIT|[69]|01pdL00000SExqc|Repository.performQuery(String)
13:21:58.2 (107059832)|SYSTEM_MODE_EXIT|true
13:21:58.2 (107070392)|METHOD_EXIT|[6]|01pdL00000SExqc|Repository.get(List<Query>)
13:21:58.2 (107075722)|SYSTEM_MODE_EXIT|false
13:21:58.2 (107193954)|FATAL_ERROR|System.QueryException: unexpected token: 'NOT'

Class.Repository.performQuery: line 336, column 1
Class.Repository.get: line 69, column 1
AnonymousBlock: line 6, column 1
AnonymousBlock: line 6, column 1
`

I was a bit puzzled because I cannot recall my last NOT LIKE query, but when I tried a native query in the developer console, it turned out that the entire NOT LIKE term needed to be enclosed in parenthesis if there are other terms in the where clause. I was not surprised to find line # 229 in the Query class and after adding the round brackets, my repo query ran successfully:

`13:42:36.2 (357167333)|USER_DEBUG|[419]|DEBUG|performQuery query:
SELECT Id, Name
FROM Profile
WHERE Name != null
AND (NOT Name LIKE :bindVar0)
13:42:36.2 (357183984)|METHOD_EXIT|[335]|01pdL00000SExqc|Repository.logQuery(String)
13:42:36.2 (357188514)|STATEMENT_EXECUTE|[336]
13:42:36.2 (357871291)|SOQL_EXECUTE_BEGIN|[336]|Aggregations:0|SELECT Id, Name
FROM Profile
WHERE Name != null
AND (NOT Name LIKE :bindVar0)
13:42:36.2 (375185209)|SOQL_EXECUTE_END|[336]|Rows:44
`

I hope this is the right way to solve the issue, please let me know if not and I am happy to change the code accordingly.

Kind regards,
Jan

